### PR TITLE
fix: map and send all user attributes including custom attributes

### DIFF
--- a/src/methods/identify.ts
+++ b/src/methods/identify.ts
@@ -4,10 +4,7 @@ import * as Taplytics from 'taplytics-react-native';
 export default (event: IdentifyEventType) => {
   const userAttributes = {
     user_id: event.userId,
-    email: event.traits?.email,
-    name: event.traits?.name,
-    age: event.traits?.age,
-    gender: event.traits?.gender,
+    ...event.traits,
   };
 
   const cleanedUserAttributes = JSON.parse(JSON.stringify(userAttributes));


### PR DESCRIPTION
- map Segment traits to Taplytics user attributes: https://docs.taplytics.com/docs/react-native-sdk#set-user-attributes
- rest of the traits will be sent as custom attributes