### PR TITLE
fix: pass custom attributes as customData

### DIFF
--- a/src/methods/identify.ts
+++ b/src/methods/identify.ts
@@ -2,9 +2,17 @@ import type { IdentifyEventType } from '@segment/analytics-react-native';
 import * as Taplytics from 'taplytics-react-native';
 
 export default (event: IdentifyEventType) => {
+  const { email, firstName, lastName, name, age, gender, ...customAttributes } = event.traits;
+
   const userAttributes = {
     user_id: event.userId,
-    ...event.traits,
+    email,
+    firstName,
+    lastName,
+    name,
+    age,
+    gender,
+    customData: customAttributes,
   };
 
   const cleanedUserAttributes = JSON.parse(JSON.stringify(userAttributes));


### PR DESCRIPTION
- as the React Native SDK only accepts the custom attributes in the `customData` field https://docs.taplytics.com/docs/react-native-sdk#set-user-attributes
- so users don't have to duplicate their custom attributes when calling identify