### PR TITLE
fix: support customData attribute to be passed in

### DIFF
--- a/src/methods/identify.ts
+++ b/src/methods/identify.ts
@@ -2,7 +2,7 @@ import type { IdentifyEventType } from '@segment/analytics-react-native';
 import * as Taplytics from 'taplytics-react-native';
 
 export default (event: IdentifyEventType) => {
-  const { email, firstName, lastName, name, age, gender, ...customAttributes } = event.traits;
+  const { email, firstName, lastName, name, age, gender, customData, ...customAttributes } = event.traits;
 
   const userAttributes = {
     user_id: event.userId,
@@ -12,7 +12,10 @@ export default (event: IdentifyEventType) => {
     name,
     age,
     gender,
-    customData: customAttributes,
+    customData: {
+      ...(typeof customData === 'object' ? customData : {}),
+      ...customAttributes,
+    },
   };
 
   const cleanedUserAttributes = JSON.parse(JSON.stringify(userAttributes));


### PR DESCRIPTION
- allow attributes to be passed in like so:
```
const test3 = {
    email: 'a',
    firstName: 'b',
    lastName: 'c',
    name: 'd e',
    age: 10,
    gender: 'f',
    employee: true,
    another: 12,
    stuff: {
        help: 'sjdf'
    },
    customData: {
         yes: "hi"
     }
};
    - and have all custom attributes not defined here https://docs.taplytics.com/docs/react-native-sdk#user-attributes passed in as `customData`